### PR TITLE
Support for SQL 2025 vector and json types

### DIFF
--- a/src/Pingmint.CodeGen.Sql/Analyzer.cs
+++ b/src/Pingmint.CodeGen.Sql/Analyzer.cs
@@ -466,6 +466,8 @@ public class Analyzer
                     "xml" => SqlDbType.Xml,
                     "uniqueidentifier" => SqlDbType.UniqueIdentifier,
                     "image" => SqlDbType.Image,
+                    "vector" => SqlDbType.Vector,
+                    "json" => SqlDbType.Json,
 
                     _ => (SqlDbType?)null,
                 } is not { } value)
@@ -502,7 +504,8 @@ public class Analyzer
         SqlDbType.NVarChar or
         SqlDbType.Text or
         SqlDbType.VarChar or
-        SqlDbType.Xml
+        SqlDbType.Xml or
+        SqlDbType.Json
         => typeof(String),
 
         SqlDbType.DateTimeOffset => typeof(DateTimeOffset),
@@ -557,6 +560,18 @@ public class Analyzer
         if (await GetSysTypeAsync(server, systemTypeId, userTypeId) is not { } foundSysType)
         {
             throw new InvalidOperationException("Could not find sys.types row for " + systemTypeId + ", " + userTypeId);
+        }
+
+        if (foundSysType.Name == "vector")
+        {
+            _csharpTypeInfosById[(systemTypeId, userTypeId)] = cachedValue = new()
+            {
+                TypeRef = "SqlVector<float>",
+                TypeRefNullable = "SqlVector<float>?",
+                IsValueType = true,
+                SqlDbType = SqlDbType.Vector,
+            };
+            return cachedValue;
         }
 
         if (!foundSysType.IsUserDefined)

--- a/src/Pingmint.CodeGen.Sql/CodeFile.cs
+++ b/src/Pingmint.CodeGen.Sql/CodeFile.cs
@@ -41,6 +41,7 @@ public class CodeFile
         code.UsingNamespace("System.Threading");
         code.UsingNamespace("System.Threading.Tasks");
         code.UsingNamespace("Microsoft.Data.SqlClient");
+        code.UsingNamespace("Microsoft.Data.SqlTypes");
         code.Line($"using static {Namespace}.FileMethods;");
         code.Line();
 

--- a/src/Pingmint.CodeGen.Sql/Pingmint.CodeGen.Sql.csproj
+++ b/src/Pingmint.CodeGen.Sql/Pingmint.CodeGen.Sql.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>0.48</Version>
+    <Version>0.49</Version>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
This PR adds support for the new SQL 2025 'vector' and 'json' types. 'vector' is mapped to 'SqlVector<float>' and 'json' is mapped to 'String'.